### PR TITLE
Make `BFraction` protocols match `BInt`

### DIFF
--- a/Sources/BigInt/BigFrac.swift
+++ b/Sources/BigInt/BigFrac.swift
@@ -5,7 +5,7 @@
 //  Created by Leif Ibsen on 26/06/2022.
 //
 
-public struct BFraction: CustomStringConvertible, Comparable, Equatable {
+public struct BFraction: CustomStringConvertible, Comparable, Codable, Sendable, Equatable, Hashable {
     
     mutating func normalize() {
         let g = self.numerator.gcd(self.denominator)


### PR DESCRIPTION
Essentially adds `Codable`, `Sendable`, and `Hashable` to `BFraction`. The important things is `BFraction` being `Sendable`, without it `BFraction` generates errors when used in a `Swift 6` package.